### PR TITLE
  dependencies class not matched from arcloder

### DIFF
--- a/res/layout/activity_affected_countries.xml
+++ b/res/layout/activity_affected_countries.xml
@@ -26,14 +26,13 @@
         android:id="@+id/listView"
         android:layout_below="@+id/edtSearch"
         android:layout_margin="10dp"/>
-    <com.leo.simplearcloader.SimpleArcLoader
-        android:layout_width="60dp"
-        android:layout_height="60dp"
-        android:id="@+id/loader"
-        app:arc_style="simple_arc"
-        android:visibility="visible"
-        android:layout_centerInParent="true"/>
-
+   <ProgressBar
+      android:id="@+id/determinateBar"
+      style="@android:style/Widget.ProgressBar.Horizontal"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:progress="25"/>
+ 
 
 
 </RelativeLayout>


### PR DESCRIPTION
  dependencies {       compile 'com.leo.simplearcloader:simplearcloader:1.0.+'   } Class referenced in the layout file, com.leo.simplearcloader.SimpleArcLoader, was not found in the project or the libraries